### PR TITLE
feat: add CSV import/export and lead status tracking

### DIFF
--- a/campaign.html
+++ b/campaign.html
@@ -10,7 +10,10 @@
 </head>
 <body>
   <h3 id="username"></h3>
+  <div id="status"></div>
   <button id="open-profile">Open Profile</button>
+  <button id="mark-contacted">Mark as Contacted</button>
+  <button id="mark-skipped">Mark as Skipped</button>
   <textarea id="message"></textarea>
   <div id="stats"></div>
   <button id="next">Next</button>

--- a/campaign.js
+++ b/campaign.js
@@ -2,6 +2,7 @@ let usernames = [];
 let index = 0;
 let messageBox;
 let generateBtn;
+let statuses = {};
 
 document.addEventListener('DOMContentLoaded', init);
 
@@ -10,8 +11,11 @@ async function init() {
   const listName = params.get('list');
   const lists = await Storage.getLists();
   usernames = lists[listName] || [];
+  statuses = await Storage.getLeadsWithStatus();
   document.getElementById('next').addEventListener('click', next);
   document.getElementById('open-profile').addEventListener('click', openProfile);
+  document.getElementById('mark-contacted').addEventListener('click', () => setStatus('contacted'));
+  document.getElementById('mark-skipped').addEventListener('click', () => setStatus('skipped'));
   messageBox = document.getElementById('message');
   generateBtn = document.createElement('button');
   generateBtn.id = 'generate-dm';
@@ -31,6 +35,8 @@ function update() {
   const username = usernames[index];
   document.getElementById('username').textContent = '@' + username;
   document.getElementById('stats').textContent = `${index} of ${usernames.length} contacted`;
+  const status = statuses[username] || '';
+  document.getElementById('status').textContent = status ? `Status: ${status}` : '';
   messageBox.value = '';
 }
 
@@ -41,6 +47,13 @@ function openProfile() {
 
 function next() {
   index++;
+  update();
+}
+
+async function setStatus(status) {
+  const username = usernames[index];
+  await Storage.updateStatus(username, status);
+  statuses[username] = status;
   update();
 }
 

--- a/popup.html
+++ b/popup.html
@@ -16,9 +16,11 @@
   <ul id="usernames"></ul>
   <hr/>
   <button id="collect">Collect from Page</button>
-  <button id="export">Export CSV</button>
-  <input type="file" id="import" accept=".csv" style="display:none" />
-  <button id="import-btn">Import CSV</button>
+  <div id="csv-controls">
+    <button id="export">Export CSV</button>
+    <input type="file" id="import" accept=".csv" style="display:none" />
+    <button id="import-btn">Import CSV</button>
+  </div>
   <hr/>
   <label>Template: <select id="template-select"></select></label>
   <button id="start-campaign">Start Campaign</button>

--- a/popup.js
+++ b/popup.js
@@ -61,9 +61,8 @@ async function collectFromPage() {
 
 async function exportCSV() {
   const listName = document.getElementById('list-select').value;
-  const lists = await Storage.getLists();
-  const usernames = lists[listName] || [];
-  const csv = usernames.join('\n');
+  if (!listName) return alert('Select a list first.');
+  const csv = await Storage.exportListCSV(listName);
   const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }));
   chrome.downloads?.download({ url, filename: `${listName}.csv` });
 }
@@ -72,9 +71,12 @@ async function importCSV(e) {
   const file = e.target.files[0];
   if (!file) return;
   const text = await file.text();
-  const usernames = text.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
   const listName = document.getElementById('list-select').value;
-  await Storage.addToList(listName, usernames);
+  if (!listName) {
+    alert('Select a list first.');
+    return;
+  }
+  await Storage.importCSVToList(listName, text);
   renderUsernames();
   e.target.value = '';
 }

--- a/storage.js
+++ b/storage.js
@@ -12,6 +12,19 @@ const Storage = {
   async saveLists(lists) {
     return this.set('lists', lists);
   },
+  async exportListCSV(listName) {
+    const lists = await this.getLists();
+    const usernames = lists[listName] || [];
+    return ['username', ...usernames].join('\n');
+  },
+  async importCSVToList(listName, csvText) {
+    const usernames = csvText
+      .split(/\r?\n/)
+      .flatMap(line => line.split(','))
+      .map(u => u.trim())
+      .filter(u => u && u.toLowerCase() !== 'username');
+    return this.addToList(listName, usernames);
+  },
   async addToList(listName, usernames) {
     const lists = await this.getLists();
     if (!lists[listName]) lists[listName] = [];
@@ -35,6 +48,14 @@ const Storage = {
     const lists = await this.getLists();
     delete lists[listName];
     return this.saveLists(lists);
+  },
+  async updateStatus(username, status) {
+    const statuses = (await this.get('statuses')) || {};
+    statuses[username] = status;
+    return this.set('statuses', statuses);
+  },
+  async getLeadsWithStatus() {
+    return (await this.get('statuses')) || {};
   },
   async getTemplates() {
     return (await this.get('templates')) || {};


### PR DESCRIPTION
## Summary
- add UI controls for CSV import/export
- support reading/writing list CSVs via storage helpers
- allow marking leads as contacted or skipped with status tracking in the campaign dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b35b0162f0832fade2faf8cf15eb06