### PR TITLE
feat: track lead statuses across UI and storage

### DIFF
--- a/campaign.html
+++ b/campaign.html
@@ -10,7 +10,10 @@
 </head>
 <body>
   <h3 id="username"></h3>
+  <div id="status"></div>
   <button id="open-profile">Open Profile</button>
+  <button id="mark-contacted">Mark as Contacted</button>
+  <button id="mark-skipped">Mark as Skipped</button>
   <textarea id="message"></textarea>
   <div id="stats"></div>
   <button id="next">Next</button>

--- a/campaign.js
+++ b/campaign.js
@@ -2,6 +2,7 @@ let usernames = [];
 let index = 0;
 let messageBox;
 let generateBtn;
+let statuses = {};
 
 document.addEventListener('DOMContentLoaded', init);
 
@@ -10,8 +11,11 @@ async function init() {
   const listName = params.get('list');
   const lists = await Storage.getLists();
   usernames = lists[listName] || [];
+  statuses = await Storage.getLeadsWithStatus();
   document.getElementById('next').addEventListener('click', next);
   document.getElementById('open-profile').addEventListener('click', openProfile);
+  document.getElementById('mark-contacted').addEventListener('click', () => setStatus('Contacted'));
+  document.getElementById('mark-skipped').addEventListener('click', () => setStatus('Skipped'));
   messageBox = document.getElementById('message');
   generateBtn = document.createElement('button');
   generateBtn.id = 'generate-dm';
@@ -30,7 +34,10 @@ function update() {
   }
   const username = usernames[index];
   document.getElementById('username').textContent = '@' + username;
-  document.getElementById('stats').textContent = `${index} of ${usernames.length} contacted`;
+  const contactedCount = Object.values(statuses).filter(s => s === 'Contacted').length;
+  document.getElementById('stats').textContent = `${contactedCount} of ${usernames.length} contacted`;
+  const status = statuses[username] || '';
+  document.getElementById('status').textContent = status ? `Status: ${status}` : '';
   messageBox.value = '';
 }
 
@@ -41,6 +48,13 @@ function openProfile() {
 
 function next() {
   index++;
+  update();
+}
+
+async function setStatus(status) {
+  const username = usernames[index];
+  await Storage.updateStatus(username, status);
+  statuses[username] = status;
   update();
 }
 

--- a/popup.html
+++ b/popup.html
@@ -14,11 +14,14 @@
   <select id="list-select"></select>
   <button id="create-list">New List</button>
   <ul id="usernames"></ul>
+  <div id="counts"></div>
   <hr/>
   <button id="collect">Collect from Page</button>
-  <button id="export">Export CSV</button>
-  <input type="file" id="import" accept=".csv" style="display:none" />
-  <button id="import-btn">Import CSV</button>
+  <div id="csv-controls">
+    <button id="export">Export CSV</button>
+    <input type="file" id="import" accept=".csv" style="display:none" />
+    <button id="import-btn">Import CSV</button>
+  </div>
   <hr/>
   <label>Template: <select id="template-select"></select></label>
   <button id="start-campaign">Start Campaign</button>

--- a/popup.js
+++ b/popup.js
@@ -10,7 +10,6 @@ async function init() {
   document.getElementById('import').addEventListener('change', importCSV);
   document.getElementById('start-campaign').addEventListener('click', startCampaign);
 }
-
 async function loadLists() {
   const select = document.getElementById('list-select');
   const lists = await Storage.getLists();
@@ -38,13 +37,30 @@ async function createList() {
 async function renderUsernames() {
   const listName = document.getElementById('list-select').value;
   const lists = await Storage.getLists();
+  const statuses = await Storage.getLeadsWithStatus();
   const ul = document.getElementById('usernames');
   ul.innerHTML = '';
   (lists[listName] || []).forEach(u => {
     const li = document.createElement('li');
-    li.textContent = u;
+    const span = document.createElement('span');
+    span.textContent = u + ' ';
+    const select = document.createElement('select');
+    ['Not Contacted', 'Contacted', 'Skipped'].forEach(val => {
+      const opt = document.createElement('option');
+      opt.value = val;
+      opt.textContent = val;
+      select.appendChild(opt);
+    });
+    select.value = statuses[u] || 'Not Contacted';
+    select.addEventListener('change', async e => {
+      await Storage.updateStatus(u, e.target.value);
+      renderCounts();
+    });
+    li.appendChild(span);
+    li.appendChild(select);
     ul.appendChild(li);
   });
+  renderCounts();
 }
 
 async function collectFromPage() {
@@ -61,9 +77,8 @@ async function collectFromPage() {
 
 async function exportCSV() {
   const listName = document.getElementById('list-select').value;
-  const lists = await Storage.getLists();
-  const usernames = lists[listName] || [];
-  const csv = usernames.join('\n');
+  if (!listName) return alert('Select a list first.');
+  const csv = await Storage.exportListCSV(listName);
   const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }));
   chrome.downloads?.download({ url, filename: `${listName}.csv` });
 }
@@ -72,9 +87,12 @@ async function importCSV(e) {
   const file = e.target.files[0];
   if (!file) return;
   const text = await file.text();
-  const usernames = text.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
   const listName = document.getElementById('list-select').value;
-  await Storage.addToList(listName, usernames);
+  if (!listName) {
+    alert('Select a list first.');
+    return;
+  }
+  await Storage.importCSVToList(listName, text);
   renderUsernames();
   e.target.value = '';
 }
@@ -85,6 +103,22 @@ function startCampaign() {
   if (!listName) return alert('Select a list.');
   const url = chrome.runtime.getURL(`campaign.html?list=${encodeURIComponent(listName)}&template=${encodeURIComponent(template)}`);
   chrome.tabs.create({ url });
+}
+
+async function renderCounts() {
+  const listName = document.getElementById('list-select').value;
+  const lists = await Storage.getLists();
+  const statuses = await Storage.getLeadsWithStatus();
+  const usernames = lists[listName] || [];
+  let contacted = 0;
+  let skipped = 0;
+  usernames.forEach(u => {
+    if (statuses[u] === 'Contacted') contacted++;
+    if (statuses[u] === 'Skipped') skipped++;
+  });
+  const total = usernames.length;
+  const div = document.getElementById('counts');
+  div.textContent = `Total: ${total} | Contacted: ${contacted} | Skipped: ${skipped}`;
 }
 
 async function loadTemplates() {


### PR DESCRIPTION
## Summary
- show per-lead status dropdown and live contacted/skipped counters in the popup
- persist lead statuses and include them in CSV import/export helpers
- enable campaign dashboard buttons to mark leads contacted or skipped and display status, including contacted count in campaign stats

## Testing
- `node --check popup.js storage.js campaign.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b35b0162f0832fade2faf8cf15eb06